### PR TITLE
Unlocked AI Capabilities for the Apex RPG7

### DIFF
--- a/addons/ai/CfgAmmo.hpp
+++ b/addons/ai/CfgAmmo.hpp
@@ -1,5 +1,4 @@
 class CfgAmmo {
-	class RocketCore;
 	class RocketBase;
 	class R_PG7_F : RocketBase {
 		airLock = 1;

--- a/addons/ai/CfgAmmo.hpp
+++ b/addons/ai/CfgAmmo.hpp
@@ -1,0 +1,8 @@
+class CfgAmmo {
+	class RocketCore;
+	class RocketBase;
+	class R_PG7_F : RocketBase {
+		airLock = 1;
+		allowAgainstInfantry = 1;
+	};
+};

--- a/addons/ai/config.cpp
+++ b/addons/ai/config.cpp
@@ -5,10 +5,7 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {
-            "A3_Weapons_F_Exp",
-            "fpa_main"
-        };
+        requiredAddons[] = {"fpa_main"};
         author[] = {"Cuel"};
         VERSION_CONFIG;
     };

--- a/addons/ai/config.cpp
+++ b/addons/ai/config.cpp
@@ -5,10 +5,14 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"fpa_main"};
+        requiredAddons[] = {
+            "A3_Weapons_F_Exp",
+            "fpa_main"
+        };
         author[] = {"Cuel"};
         VERSION_CONFIG;
     };
 };
 
+#include "CfgAmmo.hpp"
 #include "CfgEventHandlers.hpp"


### PR DESCRIPTION
Overriding the AI behaviour for the ammo type R_PG7_F in order to allow them to:

-Attack air assets
-Attack infantry