### PR TITLE
Update acre settings

### DIFF
--- a/extra/cba_settings_userconfig/cba_settings.sqf
+++ b/extra/cba_settings_userconfig/cba_settings.sqf
@@ -6,7 +6,6 @@ force force acre_sys_core_ignoreAntennaDirection = true;
 force acre_sys_core_revealToAI = 1;
 acre_sys_core_terrainLoss = 0.5;
 
-
 // ACE Misc
 ace_common_persistentLaserEnabled = false;
 force ace_hitreactions_minDamageToTrigger = 0.1;

--- a/extra/cba_settings_userconfig/cba_settings.sqf
+++ b/extra/cba_settings_userconfig/cba_settings.sqf
@@ -3,8 +3,9 @@ force force acre_sys_core_ts3ChannelSwitch = true;
 force force acre_sys_core_interference = false;
 force force acre_sys_core_fullDuplex = true;
 force force acre_sys_core_ignoreAntennaDirection = true;
-force acre_sys_core_revealToAI = true;
-acre_sys_core_terrainLoss = 0.2;
+force acre_sys_core_revealToAI = 1;
+acre_sys_core_terrainLoss = 0.5;
+
 
 // ACE Misc
 ace_common_persistentLaserEnabled = false;


### PR DESCRIPTION
Reason for new value suggestions:

- Reveal to AI is now a float value and not a boolean anymore
- Terrain loss has been revamped. It was at 0.5 since forever, but with the new terrain loss models it is back on 1. meaning we go half as usual.