### PR TITLE
Update cba_settings.sqf

### DIFF
--- a/extra/cba_settings_userconfig/cba_settings.sqf
+++ b/extra/cba_settings_userconfig/cba_settings.sqf
@@ -23,12 +23,7 @@ force ace_cargo_paradropTimeCoefficent = 2;
 
 // ACE Advanced Fatigue
 force ace_advanced_fatigue_enabled = false;
-force ace_advanced_fatigue_enableStaminaBar = true;
-force ace_advanced_fatigue_loadFactor = 1;
-force ace_advanced_fatigue_performanceFactor = 1;
-force ace_advanced_fatigue_recoveryFactor = 1;
 force ace_advanced_fatigue_swayFactor = 0.4;
-force ace_advanced_fatigue_terrainGradientFactor = 1;
 
 // ACE Common
 force force ace_common_checkPBOsAction = 0;

--- a/extra/cba_settings_userconfig/cba_settings.sqf
+++ b/extra/cba_settings_userconfig/cba_settings.sqf
@@ -16,11 +16,19 @@ force ace_switchunits_enableSwitchUnits = false;
 force ace_vehiclelock_vehicleStartingLockState = -1;
 force ace_scopes_enabled = true;
 force ace_noradio_enabled = true;
-force force ace_advanced_fatigue_enabled = false;
 force force ace_microdagr_mapDataAvailable = 2;
 force force ace_gforces_enabledFor = 1;
 force force ace_cargo_enable = true;
 force ace_cargo_paradropTimeCoefficent = 2;
+
+// ACE Advanced Fatigue
+force ace_advanced_fatigue_enabled = false;
+force ace_advanced_fatigue_enableStaminaBar = true;
+force ace_advanced_fatigue_loadFactor = 1;
+force ace_advanced_fatigue_performanceFactor = 1;
+force ace_advanced_fatigue_recoveryFactor = 1;
+force ace_advanced_fatigue_swayFactor = 0.4;
+force ace_advanced_fatigue_terrainGradientFactor = 1;
 
 // ACE Common
 force force ace_common_checkPBOsAction = 0;
@@ -247,7 +255,7 @@ force acex_viewrestriction_modeSelectiveAir = 0;
 force acex_viewrestriction_modeSelectiveSea = 0;
 
 // ACEX HC
-force force acex_headless_enabled = true;
+force acex_headless_enabled = true;
 force force acex_headless_delay = 60;
 force force acex_headless_endMission = 2;
 force acex_headless_log = false;


### PR DESCRIPTION
Unlocked the setting to disable automatic headless transfer in case mission maker want to utilize that.
Unlocked the setting to enable ace advanced fatigue in case mission makers want to enable it outside of sunday sessions.
Moved the advanced fatigue settings out of misc into its own category.