### PR TITLE
Reply message command and some QoL stuff

### DIFF
--- a/addons/acre_gestures/CfgMoves.hpp
+++ b/addons/acre_gestures/CfgMoves.hpp
@@ -1,16 +1,23 @@
 class CfgMovesBasic {
-    class DefaultDie;
     class ManActions {
         acre_radio_helmet = "acre_radio_helmet";
+        acre_radio_helmet_NoADS = "acre_radio_helmet_NoADS";
+
         acre_radio_vest = "acre_radio_vest";
+        acre_radio_vest_NoADS = "acre_radio_vest_NoADS";
+
         acre_radio_stop = "acre_radio_stop";
     };
     class Actions {
         class Default;
         class NoActions: ManActions {
-            acre_radio_helmet[] = {"acre_radio_helmet","Gesture"};
-            acre_radio_vest[] = {"acre_radio_vest","Gesture"};
-            acre_radio_stop[] = {"acre_radio_stop","Gesture"};
+            acre_radio_helmet[] = {"acre_radio_helmet", "Gesture"};
+            acre_radio_helmet_NoADS[] = {"acre_radio_helmet_NoADS", "Gesture"};
+
+            acre_radio_vest[] = {"acre_radio_vest", "Gesture"};
+            acre_radio_vest_NoADS[] = {"acre_radio_vest_NoADS", "Gesture"};
+
+            acre_radio_stop[] = {"acre_radio_stop", "Gesture"};
         };
     };
 };
@@ -29,7 +36,7 @@ class CfgGesturesMale {
             disableWeaponsLong = 0;
             enableBinocular = 1;
             enableMissile = 1;
-            enableOptics = 1; //was 0
+            enableOptics = 1;
             equivalentTo = "";
             forceAim = 0;
             headBobMode = 0;
@@ -50,7 +57,7 @@ class CfgGesturesMale {
             showItemInHand = 0;
             showItemInRightHand = 0;
             showWeaponAim = 1;
-            soundEdge[] = {0.5,1};
+            soundEdge[] = {0.5, 1};
             soundEnabled = 1;
             soundOverride = "";
             speed = 0.3;
@@ -65,15 +72,24 @@ class CfgGesturesMale {
             rightHandIKCurve[] = {1};
             rightHandIKEnd = 1;
         };
+
         class acre_radio_helmet: acre_radio_base {
             file = "a3\anims_f_epa\data\anim\sdr\cts\custom\a_in\acts_listeningtoradioloop.rtm";
             minPlayTime = 2;
             mask = "acre_UpperBodyNoRArm";
         };
+        class acre_radio_helmet_NoADS: acre_radio_helmet {
+            enableOptics = 0;
+        };
+
         class acre_radio_vest: acre_radio_base {
             file = "a3\anims_f_bootcamp\data\anim\sdr\cts\acts_kore_talkingoverradio_loop.rtm";
             mask = "acre_UpperBodyNoRArm";
         };
+        class acre_radio_vest_NoADS: acre_radio_vest {
+            enableOptics = 0;
+        };
+
         class GestureNod;
         class acre_radio_stop: GestureNod {
             file = "a3\anims_f\data\anim\sdr\gst\gestureEmpty.rtm";
@@ -83,7 +99,16 @@ class CfgGesturesMale {
             enableOptics = 1;
         };
     };
+
     class BlendAnims {
-        acre_UpperBodyNoRArm[] = {"Weapon",0,"Pelvis",0,"Spine",0,"Spine1",0,"Spine2",0,"Spine3",0,"Camera",0,"launcher",0,"weapon",0,"launcher",0,"neck",0,"neck1",0,"head",0,"LeftShoulder",1,"LeftArm",1,"LeftArmRoll",1,"LeftForeArm",1,"LeftForeArmRoll",1,"LeftHand",1,"RightShoulder",0,"RightArm",0,"RightArmRoll",0,"RightForeArm",0,"RightForeArmRoll",0,"RightHand",0,"LeftUpLeg",0,"LeftUpLegRoll",0,"LeftLeg",0,"LeftLegRoll",0,"LeftFoot",0,"LeftToeBase",0,"RightUpLeg",0,"RightUpLegRoll",0,"RightLeg",0,"RightLegRoll",0,"RightFoot",0,"RightToeBase",0,"LeftHandIndex1",1,"LeftHandIndex2",1,"LeftHandIndex3",1,"LeftHandMiddle1",1,"LeftHandMiddle2",1,"LeftHandMiddle3",1,"LeftHandPinky1",1,"LeftHandPinky2",1,"LeftHandPinky3",1,"LeftHandThumb1",1,"LeftHandThumb2",1,"LeftHandThumb3",1,"RightHandIndex1",0,"RightHandIndex2",0,"RightHandIndex3",0,"RightHandMiddle1",0,"RightHandMiddle2",0,"RightHandMiddle3",0,"RightHandPinky1",0,"RightHandPinky2",0,"RightHandPinky3",0,"RightHandThumb1",0,"RightHandThumb2",0,"RightHandThumb3",0};
+        acre_UpperBodyNoRArm[] = {
+            "Weapon",0,"Pelvis",0,"Spine",0,"Spine1",0,"Spine2",0,"Spine3",0,"Camera",0,"launcher",0,"weapon",0,"launcher",0,"neck",0,"neck1",0,"head",0,
+            "LeftShoulder",1,"LeftArm",1,"LeftArmRoll",1,"LeftForeArm",1,"LeftForeArmRoll",1,"LeftHand",1,
+            "RightShoulder",0,"RightArm",0,"RightArmRoll",0,"RightForeArm",0,"RightForeArmRoll",0,"RightHand",0,
+            "LeftUpLeg",0,"LeftUpLegRoll",0,"LeftLeg",0,"LeftLegRoll",0,"LeftFoot",0,"LeftToeBase",0,
+            "RightUpLeg",0,"RightUpLegRoll",0,"RightLeg",0,"RightLegRoll",0,"RightFoot",0,"RightToeBase",0,
+            "LeftHandIndex1",1,"LeftHandIndex2",1,"LeftHandIndex3",1,"LeftHandMiddle1",1,"LeftHandMiddle2",1,"LeftHandMiddle3",1,"LeftHandPinky1",1,"LeftHandPinky2",1,"LeftHandPinky3",1,"LeftHandThumb1",1,"LeftHandThumb2",1,"LeftHandThumb3",1,
+            "RightHandIndex1",0,"RightHandIndex2",0,"RightHandIndex3",0,"RightHandMiddle1",0,"RightHandMiddle2",0,"RightHandMiddle3",0,"RightHandPinky1",0,"RightHandPinky2",0,"RightHandPinky3",0,"RightHandThumb1",0,"RightHandThumb2",0,"RightHandThumb3",0
+        };
     };
 };

--- a/addons/acre_gestures/XEH_postInit.sqf
+++ b/addons/acre_gestures/XEH_postInit.sqf
@@ -1,13 +1,14 @@
 #include "script_component.hpp"
-if (is3DEN || {!hasInterface || {!GVAR(enabled)}}) exitWith {};
+if (is3DEN || {!hasInterface}) exitWith {};
 
-GVAR(blackListAnims) = ["amovppnemstpsraswrfldnon","aadjppnemstpsraswrfldleft","aadjppnemstpsraswrfldright"];
+GVAR(blackListAnims) = ["amovppnemstpsraswrfldnon", "aadjppnemstpsraswrfldleft", "aadjppnemstpsraswrfldright"];
 GVAR(binoClasses) = "getText (_x >> 'simulation') == 'Binocular'" configClasses (configFile >> "CfgWeapons") apply {configName _x};
 
 ["acre_startedSpeaking", {
     params ["_unit", "_onRadio", "_radio"];
 
     if (!_onRadio ||
+        { !GVAR(enabled) } ||
         { !isNull objectParent _unit } ||
         { !(cameraView in ["INTERNAL","EXTERNAL"]) } ||
         { ace_common_isReloading } ||
@@ -21,14 +22,16 @@ GVAR(binoClasses) = "getText (_x >> 'simulation') == 'Binocular'" configClasses 
 
     private _shortRange = "343" in _radio;
 
+    private _isInAds = cameraOn isEqualTo _unit && {cameraView isEqualTo "GUNNER"};
+
     // 343 is vest mounted
     if (_hasVest && _shortRange) then {
-        _unit playActionNow "acre_radio_vest";
+        _unit playActionNow (["acre_radio_vest_NoADS", "acre_radio_vest"] select _isInAds);
     };
 
     // 148/152 is ear piece
     if (_hasHeadgear && !_shortRange) then {
-        _unit playActionNow "acre_radio_helmet";
+        _unit playActionNow (["acre_radio_helmet_NoADS", "acre_radio_helmet"] select _isInAds);
     };
 
     _unit setVariable [QGVAR(onRadio), true];
@@ -37,7 +40,7 @@ GVAR(binoClasses) = "getText (_x >> 'simulation') == 'Binocular'" configClasses 
 ["acre_stoppedSpeaking", {
     params ["_unit", "_onRadio"];
 
-    if !(_onRadio) exitWith {};
+    if (!_onRadio || {!GVAR(enabled)}) exitWith {};
 
     if (ace_common_isReloading || {_unit getVariable [QGVAR(onRadio), false]}) then {
         // If the unit started a reload while already talking, need to wait to finish to not delete a magazine

--- a/addons/acre_gestures/XEH_preInit.sqf
+++ b/addons/acre_gestures/XEH_preInit.sqf
@@ -8,7 +8,7 @@ ADDON = false;
     ["Enable ACRE gestures", "Enable ACRE gestures"],
     FP_SETTINGS,
     true,
-    true
+    false
 ] call CBA_fnc_addSetting;
 
 ADDON = true;

--- a/addons/ares/aresModules.sqf
+++ b/addons/ares/aresModules.sqf
@@ -6,7 +6,7 @@
         _pos = _obj call CBA_fnc_getPos;
     };
 
-    [_pos, true] call EFUNC(common,cameraAtPosition);
+    [_pos, false] call EFUNC(common,cameraAtPosition);
 }] call Ares_fnc_RegisterCustomModule;
 
 [UTIL, "Eject cargo", {

--- a/addons/ares/zenModules.sqf
+++ b/addons/ares/zenModules.sqf
@@ -8,7 +8,7 @@
         _pos = ASLToATL _pos;
     };
 
-    [_pos, true] call EFUNC(common,cameraAtPosition);
+    [_pos, false] call EFUNC(common,cameraAtPosition);
 }] call zen_custom_modules_fnc_register;
 
 [UTIL, "Eject cargo", {

--- a/addons/common/XEH_preInitClient.sqf
+++ b/addons/common/XEH_preInitClient.sqf
@@ -13,6 +13,7 @@ if (!hasInterface) exitWith {};
     ''
 ] call CBA_fnc_addKeybind;
 
+GVAR(lastMessageFrom) = "";
 [QGVAR(chatMessage), {
     params ["_sender", "_msg", "_type", "_receiver", ["_ping", true]];
 
@@ -43,5 +44,9 @@ if (!hasInterface) exitWith {};
         if (GVAR(customChatPingSound) && _ping) then {
             playSound "3DEN_notificationWarning";
         };
+
+        if !((toLower _type) isEqualTo "server") then {
+            GVAR(lastMessageFrom) = _sender;
+        }
     };
 }] call CBA_fnc_addEventHandler;

--- a/addons/common/commands_admins.sqf
+++ b/addons/common/commands_admins.sqf
@@ -42,7 +42,7 @@
     private _unit = _name call FUNC(getPlayer);
     if (isNull _unit) exitWith {systemChat "Could not find unit"};
 
-    [getPos _unit, true] call EFUNC(common,cameraAtPosition);
+    [getPos _unit, false] call EFUNC(common,cameraAtPosition);
     [QGVAR(chatMessage), [profileName, format ["created camera at %1", name _unit], "admin", "", false]] call CBA_fnc_globalEvent;
 }, "Creates camera at unit, acre spectator enabled <#fp.cam Cuel>"] call FUNC(registerChatCommand);
 
@@ -56,13 +56,15 @@
     _unit setDamage 0;
 }, "Fully heals unit <#fp.heal Cuel>"] call FUNC(registerChatCommand);
 
-["weaponlock", {
-    params [["_str", ""]];
-    private _disableWeapons = [false, true] select (_str isEqualTo "1");
-    [_disableWeapons, "admin"] remoteExecCall [QFUNC(disableWeapons)];
+{
+    [_x, {
+        params [["_str", ""]];
+        private _disableWeapons = [false, true] select (_str isEqualTo "1");
+        [_disableWeapons, "admin"] remoteExecCall [QFUNC(disableWeapons)];
 
-    [QGVAR(chatMessage), [profileName, format ["%1 weapons", ["enabled", "disabled"] select _disableWeapons], "", "", true]] call CBA_fnc_globalEvent;
-}, "Disable/enable all player weapons. 0 enable weapons, 1 disable weapons. <#fp.weaponlock 0/1>"] call FUNC(registerChatCommand);
+        [QGVAR(chatMessage), [profileName, format ["%1 weapons", ["enabled", "disabled"] select _disableWeapons], "", "", true]] call CBA_fnc_globalEvent;
+    }, "Disable/enable all player weapons. 0 enable weapons, 1 disable weapons. <#fp.weaponlock 0/1>"] call FUNC(registerChatCommand);
+} forEach ["wl", "weaponlock"];
 
 ["adminend", {
     ["AdminEnd", true] remoteExec [QFUNC(endMissionServer), 2];

--- a/addons/common/commands_clients.sqf
+++ b/addons/common/commands_clients.sqf
@@ -24,3 +24,15 @@
     if (_msg isEqualTo "") exitWith {};
     [_msg, "admin"] call FUNC(sendChatMessage);
 }, "Send a chat message only visible for fparma moderators <#fp.admin I require assistance>", false] call FUNC(registerChatCommand);
+
+{
+    [_x, {
+        params [["_msg", ""]];
+        _msg = [_msg] call CBA_fnc_trim;
+        if (_msg isEqualTo "") exitWith {};
+        private _receiver = [GVAR(lastMessageFrom)] call FUNC(getPlayer);
+        if (isNull _receiver) exitWith {systemChat "Could not find receiver"};
+        if (_receiver isEqualTo ([] call CBA_fnc_currentUnit)) exitWith {systemChat "Messaging yourself is not helping"};
+        [_msg, "whisper", name _receiver] call FUNC(sendChatMessage);
+    }, "Send a whisper reply to the person you last recevied a message from <#fp.r OR #fp.reply Hello stop pinging me!>", false] call FUNC(registerChatCommand);
+} forEach ["r", "reply"];

--- a/addons/common/commands_clients.sqf
+++ b/addons/common/commands_clients.sqf
@@ -1,15 +1,17 @@
-["whisper", {
-    params [["_str", ""]];
-    private _split = (_str splitString " ");
-    private _to = _split param [0, ""];
-    _split deleteAt 0;
-    private _msg = _split joinString " ";
-    if (_to isEqualTo "" || _msg isEqualTo "") exitWith {systemChat "Invalid arguments"};
+{
+    [_x, {
+        params [["_str", ""]];
+        private _split = (_str splitString " ");
+        private _to = _split param [0, ""];
+        _split deleteAt 0;
+        private _msg = _split joinString " ";
+        if (_to isEqualTo "" || _msg isEqualTo "") exitWith {systemChat "Invalid arguments"};
 
-    private _receiver = [_to] call FUNC(getPlayer);
-    if (isNull _receiver) exitWith {systemChat "Could not find receiver"};
-    [_msg, "whisper", name _receiver] call FUNC(sendChatMessage);
-}, "Send a whisper chat message only visible for receiver <#fp.whisper Cuel yo what is up>", false] call FUNC(registerChatCommand);
+        private _receiver = [_to] call FUNC(getPlayer);
+        if (isNull _receiver) exitWith {systemChat "Could not find receiver"};
+        [_msg, "whisper", name _receiver] call FUNC(sendChatMessage);
+    }, "Send a whisper chat message only visible for receiver <#fp.whisper Cuel yo what is up>", false] call FUNC(registerChatCommand);
+} forEach ["w", "whisper"];
 
 ["zeus", {
     params [["_msg", ""]];

--- a/addons/common/functions/fnc_registerChatCommand.sqf
+++ b/addons/common/functions/fnc_registerChatCommand.sqf
@@ -57,7 +57,6 @@ GVAR(chatCommands) setVariable [_fpCmd, [_description, _code, _adminOnly, _argsF
 }, "all", _fpCmd] call CBA_fnc_registerChatCommand;
 
 if !(_fpCmd isEqualTo _cmd) then {
-    systemChat format ["registering %1", _cmd];
     [_cmd, {
         [param [0, ""], _thisArgs] call FUNC(runChatCommand);
     }, "all", _fpCmd] call CBA_fnc_registerChatCommand;

--- a/addons/common/functions/fnc_registerChatCommand.sqf
+++ b/addons/common/functions/fnc_registerChatCommand.sqf
@@ -45,11 +45,20 @@ if (isNil QGVAR(chatCommands)) then {
     }, "all"] call CBA_fnc_registerChatCommand;
 };
 
-if (_cmd find "." isEqualTo -1) then {
-    _cmd = format ["fp.%1", _cmd];
+private _fpCmd = _cmd;
+if (_fpCmd find "." isEqualTo -1) then {
+    _fpCmd = format ["fp.%1", _fpCmd];
 };
 
-GVAR(chatCommands) setVariable [_cmd, [_description, _code, _adminOnly, _argsForCode]];
-[_cmd, {
+GVAR(chatCommands) setVariable [_fpCmd, [_description, _code, _adminOnly, _argsForCode]];
+
+[_fpCmd, {
     [param [0, ""], _thisArgs] call FUNC(runChatCommand);
-}, "all", _cmd] call CBA_fnc_registerChatCommand;
+}, "all", _fpCmd] call CBA_fnc_registerChatCommand;
+
+if !(_fpCmd isEqualTo _cmd) then {
+    systemChat format ["registering %1", _cmd];
+    [_cmd, {
+        [param [0, ""], _thisArgs] call FUNC(runChatCommand);
+    }, "all", _fpCmd] call CBA_fnc_registerChatCommand;
+};

--- a/extra/cba_settings_userconfig/cba_settings.sqf
+++ b/extra/cba_settings_userconfig/cba_settings.sqf
@@ -1,10 +1,10 @@
 // ACRE
 force force acre_sys_core_ts3ChannelSwitch = true;
-force force acre_sys_core_interference = false;
+// force force acre_sys_core_interference = false;
 force force acre_sys_core_fullDuplex = true;
-force force acre_sys_core_ignoreAntennaDirection = true;
-force acre_sys_core_revealToAI = 1;
-acre_sys_core_terrainLoss = 0.5;
+// force force acre_sys_core_ignoreAntennaDirection = true;
+// force acre_sys_core_revealToAI = 1;
+// acre_sys_core_terrainLoss = 0.5;
 
 // ACE Misc
 ace_common_persistentLaserEnabled = false;


### PR DESCRIPTION
Added #fp.reply to directly reply to the last message received from a player.

Added several chat command shortcuts, variations are without fp. in front and some short ones such as w (whisper), r (reply), wl (weaponlock)

Made ACRE Gesture setting local per machine, everyone can now choose if they want THEIR avatar do to them or not. While aiming down sights the gestures will not happen anymore, meaning no interruptions while aiming.