### PR TITLE
Update cba_settings.sqf

### DIFF
--- a/extra/cba_settings_userconfig/cba_settings.sqf
+++ b/extra/cba_settings_userconfig/cba_settings.sqf
@@ -32,7 +32,7 @@ force force ace_common_checkPBOsCheckAll = false;
 force force ace_common_checkPBOsWhitelist = "[]";
 
 // ACE Cookoff
-force force ace_cookoff_enable = false;
+force force ace_cookoff_enable = true;
 force ace_cookoff_enableAmmobox = true;
 force ace_cookoff_enableAmmoCookoff = true;
 force force ace_cookoff_ammoCookoffDuration = 0.2;

--- a/extra/cba_settings_userconfig/cba_settings.sqf
+++ b/extra/cba_settings_userconfig/cba_settings.sqf
@@ -32,7 +32,7 @@ force force ace_common_checkPBOsCheckAll = false;
 force force ace_common_checkPBOsWhitelist = "[]";
 
 // ACE Cookoff
-force force ace_cookoff_enable = true;
+force ace_cookoff_enable = 2;
 force ace_cookoff_enableAmmobox = true;
 force ace_cookoff_enableAmmoCookoff = true;
 force force ace_cookoff_ammoCookoffDuration = 0.2;


### PR DESCRIPTION
Recommend changing the cookoff probability to 1.0 as well, but cookoff itself works again. This doesn't impact heavier vehicles from being able to be blown up from larger explosions, and a good ATGM or larger will still destroy small cars.