### PR TITLE
Hide acre intercom ui + Acre receiver hint fix

### DIFF
--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -32,6 +32,8 @@ if (isServer) then {
     // Unassign curator on disconnect to fix bug where zeus doesn't work when reconnecting
     addMissionEventHandler ["HandleDisconnect",{
         params ["_unit"];
+        // hide acre radio helper
+        [QGVAR(removeAcreReceiverHint), [name _unit]] call CBA_fnc_globalEvent;
         private _module = getAssignedCuratorLogic _unit;
         if (isNull _module) exitWith {};
         unassignCurator _module;

--- a/addons/common/XEH_postInitClient.sqf
+++ b/addons/common/XEH_postInitClient.sqf
@@ -63,8 +63,13 @@ GVAR(acreTalking) = [];
 
 ["acre_remoteStoppedSpeaking", {
     params ["_unit"];
-    GVAR(acreTalking) = GVAR(acreTalking) - [_unit];
-    [format ["%1$%2", QGVAR(acre), name _unit]] call acre_sys_list_fnc_hideHint;
+    GVAR(acreTalking) = GVAR(acreTalking) - [_unit, objNull];
+    [QGVAR(removeAcreReceiverHint), [name _unit]] call CBA_fnc_localEvent;
+}] call CBA_fnc_addEventHandler;
+
+[QGVAR(removeAcreReceiverHint), {
+    params ["_name"];
+    [format ["%1$%2", QGVAR(acre), _name]] call acre_sys_list_fnc_hideHint;
 }] call CBA_fnc_addEventHandler;
 
 [QGVAR(acreInterruped), {

--- a/addons/common/functions/fnc_toggleScreenshotMode.sqf
+++ b/addons/common/functions/fnc_toggleScreenshotMode.sqf
@@ -18,6 +18,7 @@ if (isNil QGVAR(screenshotState)) then {
         missionNamespace getVariable ["STHud_UIMode", 0],
         missionNamespace getVariable ["ace_nametags_showplayernames", 0],
         missionNamespace getVariable ["diwako_dui_main_toggled_off", false],
+        missionNamespace getVariable [QGVAR(showReiceiverHint), false],
         shownHUD
     ];
 
@@ -25,14 +26,31 @@ if (isNil QGVAR(screenshotState)) then {
     missionNamespace setVariable ["ace_nametags_showplayernames", 0];
     missionNamespace setVariable ["diwako_dui_main_toggled_off", true];
     showHUD (shownHUD apply {false});
+    GVAR(showReiceiverHint) = false;
 
     hintSilent "";
     showChat false;
+
+    if !(isNil "acre_player") then {
+        ("acre_sys_gui_vehicleInfo" call BIS_fnc_rscLayer) cutText ["", "PLAIN"];
+    };
 } else {
     missionNamespace setVariable ["STHud_UIMode", GVAR(screenshotState) deleteAt 0];
     missionNamespace setVariable ["ace_nametags_showplayernames", GVAR(screenshotState) deleteAt 0];
     missionNamespace setVariable ["diwako_dui_main_toggled_off", GVAR(screenshotState) deleteAt 0];
+    missionNamespace setVariable [QGVAR(showReiceiverHint), GVAR(screenshotState) deleteAt 0];
     showHUD (GVAR(screenshotState) param [0, []]);
     showChat true;
+    if !(isNil "acre_player") then {
+        private _player = acre_player;
+        if !(isNull objectParent _player) then {
+            // Show UI
+            [_player, vehicle _player] call acre_sys_gui_fnc_enterVehicle;
+            // Wait until UI is initialized
+            [{
+                [vehicle _this, _this] call acre_sys_intercom_fnc_updateVehicleInfoText;
+            }, _player, 0.5] call CBA_fnc_waitAndExecute;
+        };
+    };
     GVAR(screenshotState) = nil;
 };


### PR DESCRIPTION
Hide acre intercom ui
Potential fix for the ACRE receiver hint being stuck when someone talks and then crashes