### PR TITLE
Create global vars in init instead of function

### DIFF
--- a/addons/ai/XEH_preInit.sqf
+++ b/addons/ai/XEH_preInit.sqf
@@ -5,6 +5,9 @@ ADDON = false;
 #include "XEH_PREP.hpp"
 
 if (isServer) then {
+    GVAR(cachedGroups) = [[], []] call CBA_fnc_hashCreate;
+    GVAR(activeGroups) = createHashMap;
+
     [QGVAR(updateActiveGroups), {
         params ["_newGroups", "_id"];
         private _spawnedGroups = GVAR(activeGroups) getOrDefault [_id, []];

--- a/addons/ai/functions/fnc_cache.sqf
+++ b/addons/ai/functions/fnc_cache.sqf
@@ -29,10 +29,6 @@ params [
   ["_id", "", [""]]
 ];
 
-if (isNil QGVAR(cachedGroups)) then {
-  GVAR(cachedGroups) = [[], []] call CBA_fnc_hashCreate;
-};
-
 private _isReCache = _units isEqualType "";
 if (_isReCache) then {
   _id = _units;

--- a/addons/ai/functions/fnc_spawn.sqf
+++ b/addons/ai/functions/fnc_spawn.sqf
@@ -18,10 +18,6 @@
 if (!isServer || {isNil QGVAR(savedGroups)}) exitWith {false};
 if (!params [["_id", "", [""]]]) exitWith {false};
 
-if (isNil QGVAR(activeGroups)) then {
-  GVAR(activeGroups) = createHashMap;
-};
-
 private _groups = GVAR(savedGroups) getOrDefault [_id, []];
 private _hcs = entities "HeadlessClient_F";
 if (_hcs isNotEqualTo []) then {


### PR DESCRIPTION
Since we only need to do this once, instead of checking everytime we call a spawning function, we can just create it in the pre-init setup.